### PR TITLE
feat: add support for external event id

### DIFF
--- a/src/api/scheduled-panel/scheduled-panel.dto.ts
+++ b/src/api/scheduled-panel/scheduled-panel.dto.ts
@@ -47,6 +47,10 @@ class CreateScheduledEventDTO {
     @IsInstance(Array)
     @ArrayMinSize(1)
     interviewers!: Interviewer[];
+
+    @IsOptional()
+    @IsString()
+    externalEventId?: string;
 }
 
 export class CreateScheduledPanelDTO {

--- a/src/api/scheduled-panel/scheduled-panel.entity.ts
+++ b/src/api/scheduled-panel/scheduled-panel.entity.ts
@@ -9,6 +9,7 @@ export interface ScheduledEvent {
     location?: string;
     status: 'confirmed' | 'canceled';
     interviewStepId?: string;
+    externalEventId?: string;
     interviewers: (Pick<User, 'id' | 'emails'> & {
         responseStatus: 'accepted' | 'declined' | 'needs_action' | 'tentative';
     })[];


### PR DESCRIPTION
This allows us to pair ScheduledEvents on ATSes with Events on GoodTime with certainty.
Otherwise, we will pair ScheduledEvents on ATSes with Events on GoodTime based on other properties (like start & end time) which might not be super accurate since GoodTime allows creating two Events in the same Interview that start at the same time.